### PR TITLE
Remove broken test comment

### DIFF
--- a/src/generated/prisma/index.d.ts
+++ b/src/generated/prisma/index.d.ts
@@ -1666,7 +1666,7 @@ export namespace Prisma {
     next: (params: MiddlewareParams) => $Utils.JsPromise<T>,
   ) => $Utils.JsPromise<T>
 
-  // tested in getLogLevel.test.ts
+  // Get the minimum log level from the provided array of log settings
   export function getLogLevel(log: Array<LogLevel | LogDefinition>): LogLevel | undefined;
 
   /**


### PR DESCRIPTION
## Summary
- update Prisma client comment referencing non-existent test

## Testing
- `npm test` *(fails: Missing script)*