### PR TITLE
Add article content fetching for Twitter bookmarks

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "react-dom": "^19.0.0",
     "react-hot-toast": "^2.5.2",
     "twitter-api-v2": "^1.23.2",
-    "zod": "^3.25.20"
+    "zod": "^3.25.20",
+    "node-fetch": "^3.3.2",
+    "unfluff": "^2.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -72,6 +72,7 @@ model Bookmark {
   authorUsername String
   authorImage String?
   url         String
+  articleContent String?
   createdAt   DateTime @default(now())
   importedAt  DateTime @default(now())
   userId      String

--- a/src/lib/article.ts
+++ b/src/lib/article.ts
@@ -1,0 +1,17 @@
+import fetch from 'node-fetch';
+import unfluff from 'unfluff';
+
+export async function fetchArticleContent(url: string): Promise<string | null> {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(`Failed to fetch ${url}: ${res.status}`);
+    }
+    const html = await res.text();
+    const data = unfluff(html);
+    return data.text?.trim() || null;
+  } catch (err) {
+    console.error('Error fetching article content:', err);
+    return null;
+  }
+}

--- a/src/lib/twitter.ts
+++ b/src/lib/twitter.ts
@@ -1,5 +1,6 @@
 import { TwitterApi, UserV2 } from 'twitter-api-v2';
 import { prisma } from './prisma';
+import { fetchArticleContent } from './article';
 
 interface TwitterBookmark {
   id: string;
@@ -39,9 +40,12 @@ export async function fetchTwitterBookmarks(accessToken: string, userId: string)
     
     for (const bookmark of bookmarks) {
       const author = userMap.get(bookmark.author_id);
-      
+
       if (!author) continue;
-      
+
+      const urlMatch = bookmark.text.match(/https?:\/\/\S+/);
+      const articleContent = urlMatch ? await fetchArticleContent(urlMatch[0]) : null;
+
       const bookmarkData = {
         tweetId: bookmark.id,
         content: bookmark.text,
@@ -49,6 +53,7 @@ export async function fetchTwitterBookmarks(accessToken: string, userId: string)
         authorUsername: author.username,
         authorImage: author.profile_image_url || '',
         url: `https://twitter.com/${author.username}/status/${bookmark.id}`,
+        articleContent,
         userId,
       };
       


### PR DESCRIPTION
## Summary
- add dependencies `node-fetch` and `unfluff`
- implement `fetchArticleContent` helper using these libs
- extend `Bookmark` Prisma model with `articleContent`
- enrich Twitter bookmark import with article content

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx prisma generate` *(fails: command not found)*