### PR TITLE
Add Jest tests for OpenAI digest helper

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.9.1",
@@ -32,6 +33,9 @@
     "eslint": "^9",
     "eslint-config-next": "15.3.2",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.4"
   }
 }

--- a/tests/openai.test.ts
+++ b/tests/openai.test.ts
@@ -1,0 +1,51 @@
+const createMock = jest.fn();
+
+jest.mock('openai', () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => ({
+      chat: {
+        completions: { create: createMock },
+      },
+    })),
+  };
+});
+
+import { generateDigestSummary } from '@/lib/openai';
+
+describe('generateDigestSummary', () => {
+  beforeEach(() => {
+    createMock.mockReset();
+  });
+
+  it('returns summary text on success', async () => {
+    createMock.mockResolvedValue({
+      choices: [{ message: { content: 'summary text' } }],
+    });
+    const bookmarks = [
+      {
+        authorUsername: 'user1',
+        authorName: 'User One',
+        content: 'tweet content',
+        url: 'http://example.com',
+      },
+    ] as any;
+
+    await expect(generateDigestSummary(bookmarks)).resolves.toBe('summary text');
+  });
+
+  it('throws error when openai fails', async () => {
+    const error = new Error('API failure');
+    createMock.mockRejectedValue(error);
+    const bookmarks = [
+      {
+        authorUsername: 'user1',
+        authorName: 'User One',
+        content: 'tweet content',
+        url: 'http://example.com',
+      },
+    ] as any;
+
+    await expect(generateDigestSummary(bookmarks)).rejects.toThrow('API failure');
+  });
+});


### PR DESCRIPTION
## Summary
- add a Jest configuration
- add Jest dev dependencies and test script
- mock OpenAI client in tests
- write unit tests for `generateDigestSummary`

## Testing
- `npm test` *(fails: jest not found)*